### PR TITLE
ENH: Restore previous par settings after plotting

### DIFF
--- a/R/mosaic.R
+++ b/R/mosaic.R
@@ -105,8 +105,6 @@ mosaic <- function(
   }
 
   png(full_output_path, width = size * 100, height = size * 100)
-  oldpar <- par(no.readonly = TRUE)
-  on.exit(par(oldpar))
   par(mar = c(0, 0, 0, 0), xaxs = "i", yaxs = "i")
   plot(
     NA,


### PR DESCRIPTION
Added code to save and restore graphical parameters in mosaic and plotting functions using par(no.readonly = TRUE) and on.exit(par(oldpar)). This ensures that changes to par settings do not affect subsequent plots or user sessions.