### PR TITLE
CHORE: Update examples to use `\donttest{...}` instead of `\dontrun{...}`

### DIFF
--- a/R/charisma.R
+++ b/R/charisma.R
@@ -91,7 +91,7 @@
 #' \code{\link{plot.charisma}} for visualization
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Basic usage with example image
 #' img <- system.file("extdata", "Anampses_caeruleopunctatus.png",
 #'                    package = "charisma")
@@ -100,15 +100,19 @@
 #' # With threshold to remove minor colors
 #' result <- charisma(img, threshold = 0.05)
 #'
-#' # Interactive mode with manual curation
-#' result <- charisma(img, interactive = TRUE, threshold = 0.0)
-#'
 #' # Save outputs to directory
 #' out_dir <- file.path(tempdir(), "charisma_outputs")
 #' result <- charisma(img, threshold = 0.05, logdir = out_dir)
 #'
 #' # View results
 #' plot(result)
+#' }
+#'
+#' # Interactive mode with manual curation (only runs in interactive sessions)
+#' if (interactive()) {
+#'   img <- system.file("extdata", "Anampses_caeruleopunctatus.png",
+#'                      package = "charisma")
+#'   result <- charisma(img, interactive = TRUE, threshold = 0.0)
 #' }
 #'
 #' @export

--- a/R/charisma2.R
+++ b/R/charisma2.R
@@ -56,12 +56,9 @@
 #' \code{\link{plot.charisma}} for visualization
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Load a previously saved charisma object
 #' obj <- readRDS("path/to/charisma_object.RDS")
-#'
-#' # Re-enter interactive mode with original threshold
-#' result <- charisma2(obj, interactive = TRUE)
 #'
 #' # Apply a different threshold without interactive mode
 #' result <- charisma2(obj, interactive = FALSE, new.threshold = 0.10)
@@ -71,6 +68,12 @@
 #'
 #' # Revert to a specific replacement state
 #' result <- charisma2(obj, which.state = "replace", state.index = 1)
+#' }
+#'
+#' # Re-enter interactive mode with original threshold (only runs in interactive sessions)
+#' if (interactive()) {
+#'   obj <- readRDS("path/to/charisma_object.RDS")
+#'   result <- charisma2(obj, interactive = TRUE)
 #' }
 #'
 #' @export

--- a/R/mosaic.R
+++ b/R/mosaic.R
@@ -40,14 +40,12 @@
 #'
 #' @examples
 #' # Create a mosaic from color proportions
-#' \dontrun{
 #' colors <- list(
 #'   list(hex = "#FF0000", color = "red", prop = 0.4),
 #'   list(hex = "#00FF00", color = "green", prop = 0.3),
 #'   list(hex = "#0000FF", color = "blue", prop = 0.3)
 #' )
 #' mosaic(colors, size = 10, out.path = tempdir())
-#' }
 #'
 #' @export
 mosaic <- function(

--- a/R/plot_charisma.R
+++ b/R/plot_charisma.R
@@ -47,7 +47,7 @@
 #' \code{\link{charisma2}} for batch processing
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Run charisma on an image
 #' result <- charisma("path/to/image.jpg")
 #'

--- a/R/summarize.R
+++ b/R/summarize.R
@@ -21,7 +21,7 @@
 #' \code{\link{validate}} for CLUT validation
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Run charisma on an image
 #' result <- charisma("path/to/image.jpg")
 #'

--- a/R/validate.R
+++ b/R/validate.R
@@ -42,7 +42,7 @@
 #' \code{\link{color2label}} for color classification
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Validate the default CLUT (takes a few minutes)
 #' result <- validate()
 #'


### PR DESCRIPTION
Replaced \dontrun with \donttest in example sections across multiple R files to allow examples to run during package checks, except for interactive examples which are now conditionally executed. This improves documentation usability and testing coverage.