### PR TITLE
ENH: Add progress message and test for validate function

### DIFF
--- a/R/validate.R
+++ b/R/validate.R
@@ -78,6 +78,20 @@ validate <- function(clut = charisma::clut, simple = TRUE) {
   img <- data.frame(expand.grid(h, s, v))
   colnames(img) <- c("h", "s", "v")
 
+  # Calculate total number of coordinates
+  n_coords <- nrow(img)
+  simple_text <- if (simple) " (simple = TRUE)" else " (simple = FALSE)"
+  
+  message(paste0(
+    "\n",
+    "Validating entire HSV color space with ", 
+    format(n_coords, big.mark = ","), 
+    " coordinates", 
+    simple_text, 
+    "...\n",
+    "This will take a while to run - please wait.\n"
+  ))
+
   eval_colors <- function(conditional, row) {
     h <- row[1]
     s <- row[2]

--- a/tests/testthat/test-validate.R
+++ b/tests/testthat/test-validate.R
@@ -1,0 +1,11 @@
+test_that("validate returns 0 when CLUT validation passes with no issues", {
+  # Validate the default CLUT
+  # This test may take a few minutes to run
+  result <- validate(simple = TRUE)
+
+  # When validation passes with no issues, should return 0 (numeric)
+  expect_type(result, "double")
+  expect_equal(result, 0)
+  expect_false(is.data.frame(result))
+})
+


### PR DESCRIPTION
Added a message in validate() to inform users about the number of HSV coordinates being validated and the expected runtime. Introduced a test to check that validate() returns 0 when CLUT validation passes with no issues.